### PR TITLE
Default end to true in stop method

### DIFF
--- a/bin/pixi-tween.js
+++ b/bin/pixi-tween.js
@@ -1052,14 +1052,14 @@ var Tween = function (_PIXI$utils$EventEmit) {
          *
          * @fires PIXI.tween.Tween#stop
          *
-         * @param {boolean} [end=false] - Force end to be called
+         * @param {boolean} [end=true] - Force end to be called, default to true to ensure cleanup of Promises
          * @returns {PIXI.tween.Tween} - This tween instance
          */
 
     }, {
         key: 'stop',
         value: function stop() {
-            var end = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+            var end = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
             this._active = false;
             this.emit('stop');

--- a/bin/pixi-tween.js
+++ b/bin/pixi-tween.js
@@ -1052,7 +1052,7 @@ var Tween = function (_PIXI$utils$EventEmit) {
          *
          * @fires PIXI.tween.Tween#stop
          *
-         * @param {boolean} [end=true] - Force end to be called, default to true to ensure cleanup of Promises
+         * @param {boolean} [end=true] - Force end to be called, default to true to ensure cleanup of Promises created for the tween (if any)
          * @returns {PIXI.tween.Tween} - This tween instance
          */
 

--- a/bin/pixi-tween.js
+++ b/bin/pixi-tween.js
@@ -1052,14 +1052,14 @@ var Tween = function (_PIXI$utils$EventEmit) {
          *
          * @fires PIXI.tween.Tween#stop
          *
-         * @param {boolean} [end=true] - Force end to be called, default to true to ensure cleanup of Promises created for the tween (if any)
+         * @param {boolean} [end=false] - Force end to be called
          * @returns {PIXI.tween.Tween} - This tween instance
          */
 
     }, {
         key: 'stop',
         value: function stop() {
-            var end = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
+            var end = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
 
             this._active = false;
             this.emit('stop');

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -348,10 +348,10 @@ export default class Tween extends PIXI.utils.EventEmitter {
      *
      * @fires PIXI.tween.Tween#stop
      *
-     * @param {boolean} [end=false] - Force end to be called
+     * @param {boolean} [end=true] - Force end to be called, default to true to ensure cleanup of Promises created for the tween (if any)
      * @returns {PIXI.tween.Tween} - This tween instance
      */
-    stop(end = false) {
+    stop(end = true) {
         this._active = false;
         this.emit('stop');
 


### PR DESCRIPTION
Promises (if any created) should be cleaned up by via the _end method by default.